### PR TITLE
Fix total candidates display in search results

### DIFF
--- a/src/app/perfil-candidato/components/SearchSection.tsx
+++ b/src/app/perfil-candidato/components/SearchSection.tsx
@@ -163,7 +163,7 @@ export const SearchSection = ({ title }: { title: string; filters: any }) => {
                 Resultados encontrados:
               </Text>
               <Text textType="span" size="L1" className="font-bold">
-                {result?.results?.length || 0} candidatos
+                {result?.totalResults || 0} candidatos
               </Text>
             </div>
             {result.length > 0 && (


### PR DESCRIPTION
Adjusts the candidate search results display to show the total number of candidates found instead of the total on the current page. This change addresses issue #74.